### PR TITLE
Enable DB signing via a flag

### DIFF
--- a/scaffolder-templates/chatbot-rag-kickstart-template/manifests/argocd/${{values.name}}-argocd-rag-ui.yaml
+++ b/scaffolder-templates/chatbot-rag-kickstart-template/manifests/argocd/${{values.name}}-argocd-rag-ui.yaml
@@ -26,6 +26,8 @@ spec:
           value: "http://${{ values.name }}-rag-ui-mcp-weather:8000/sse"
         - name: llm-service.secret.enabled
           value: "false"
+        - name: ingestion-pipeline.enableSigning
+          value: "${{ values.enable_db_signing }}"
       values: |
         llama-stack:
           secrets: {}

--- a/scaffolder-templates/chatbot-rag-kickstart-template/template.yaml
+++ b/scaffolder-templates/chatbot-rag-kickstart-template/template.yaml
@@ -155,6 +155,11 @@ spec:
                   - safety
     - title: Default Ingestion Pipeline
       properties:
+        signDatabase:
+          title: Enable Embeddings Database Signing
+          type: boolean
+          description: Enable embeddings database signing
+          default: false
         injection_pipeline_name:
           title: Ingestion Pipeline Name
           type: string
@@ -297,6 +302,7 @@ spec:
           endpoint_url: ${{ parameters.endpoint_url }}
           region: ${{ parameters.region }}
           enable_safety: ${{ parameters.enableSafety }}
+          enable_db_signing: ${{ parameters.signDatabase }}
           # enbableGPUSupport: ${{ parameters.enbableGPUSupport }}
           # createGPU: ${{ parameters.createGPU }}
     - id: fetch-build-pipeline


### PR DESCRIPTION
GitOps does not contact the cluster when rendering the template. So instead of using the presence of namespaces to activate the feature, a new flag is added, controlled by the user.